### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ cmake --build build
 $ cmake --install build --strip
 
 $ # ..or by Meson
-$ meson setup build
+$ meson setup build src
 $ meson install -C build --strip
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ Next, drop to your shell and compile platform-dependent module from source.
 
 4. Compiling
 ```
-    $ cd ~/.config/nvim/pack/minpac/start/neoclip/src
+$ cd ~/.config/nvim/pack/minpac/start/neoclip/src
 
-    $ # by CMake
-    $ cmake -B build
-    $ cmake --build build
-    $ cmake --install build --strip
+$ # by CMake
+$ cmake -S src -B build
+$ cmake --build build
+$ cmake --install build --strip
 
-    $ # ..or by Meson
-    $ meson setup build
-    $ meson install -C build --strip
+$ # ..or by Meson
+$ meson setup build
+$ meson install -C build --strip
 ```
 
 5. Run Neovim again and see if it's all right

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ under your packages directory tree, see `:h packages`.
 
 An example for [minpac][2]
 
+0. Download source code
+```
+git clone https://github.com/matveyt/neoclip ~/.config/nvim/pack/minpac/start/neoclip/src
+```
 1. Add to your `init.vim`
 ```
     call minpac#init()


### PR DESCRIPTION
This is draft and more bug report about [neoclip](https://stackoverflow.com/a/67644112/7915017). I can't use `update | source %` 
```
E499: Empty file name for '%' or '#', only works with ":p:h"
```
```
$ nvim --version
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1703358377

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"

Run :checkhealth for more info
```
What is wrong?